### PR TITLE
fix: 안드로이드 마커 깜빡거리는 현상 해결

### DIFF
--- a/android/src/main/java/com/mjstudio/reactnativenavermap/overlay/marker/RNCNaverMapMarker.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/overlay/marker/RNCNaverMapMarker.kt
@@ -4,6 +4,9 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import android.view.View
 import androidx.core.view.children
 import com.airbnb.android.react.maps.TrackableView
@@ -26,9 +29,16 @@ class RNCNaverMapMarker(
   private var customViewBitmap: Bitmap? = null
 
   private var isImageSetFromSubview = false
+  private var isUpdating = false
+  private var pendingMap: NaverMap? = null
 
   override val overlay: Marker by lazy {
     Marker().apply {
+      icon = OverlayImage.fromBitmap(
+        Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888).apply {
+          eraseColor(Color.TRANSPARENT)
+        }
+      )
       setOnClickListener {
         reactContext.emitEvent(id) { surfaceId, reactTag ->
           NaverMapOverlayTapEvent(
@@ -42,14 +52,95 @@ class RNCNaverMapMarker(
   }
 
   override fun addToMap(map: NaverMap) {
-    overlay.map = map
+    if (customView != null) {
+      // 커스텀 뷰가 있는 경우 맵 추가를 보류
+      pendingMap = map
+      scheduleUpdate()
+    } else {
+      // 일반 마커의 경우 바로 추가
+      overlay.map = map
+    }
   }
 
   override fun removeFromMap(map: NaverMap) {
+    pendingMap = null
     overlay.map = null
   }
 
+  private fun recycleBitmap() {
+    customViewBitmap?.let { bitmap ->
+      if (!bitmap.isRecycled) {
+        bitmap.recycle()
+      }
+      customViewBitmap = null
+    }
+  }
+
+  @Synchronized
+  private fun updateCustomView() {
+    if (isUpdating) return
+
+    try {
+      isUpdating = true
+
+      val needNewBitmap = customViewBitmap == null ||
+              customViewBitmap!!.isRecycled ||
+              customViewBitmap?.width != overlay.width ||
+              customViewBitmap?.height != overlay.height
+
+      if (needNewBitmap) {
+        val newBitmap = Bitmap.createBitmap(
+          max(1, overlay.width),
+          max(1, overlay.height),
+          Bitmap.Config.ARGB_8888
+        )
+
+        val oldBitmap = customViewBitmap
+        customViewBitmap = newBitmap
+        oldBitmap?.recycle()
+      }
+
+      customView?.let { view ->
+        customViewBitmap?.let { bitmap ->
+          bitmap.eraseColor(Color.TRANSPARENT)
+          val canvas = Canvas(bitmap)
+          view.draw(canvas)
+
+          overlay.icon = OverlayImage.fromBitmap(bitmap)
+
+          // 커스텀 뷰가 준비된 후에 맵에 추가
+          pendingMap?.let { map ->
+            overlay.map = map
+            pendingMap = null
+          }
+        }
+      }
+    } catch (e: Exception) {
+      Log.e("RNCNaverMapMarker", "Failed to update custom view", e)
+    } finally {
+      isUpdating = false
+    }
+  }
+
+  // 디바운스 처리를 위한 핸들러
+  private val updateHandler = Handler(Looper.getMainLooper())
+  private var pendingUpdate: Runnable? = null
+
+  private fun scheduleUpdate() {
+    pendingUpdate?.let { updateHandler.removeCallbacks(it) }
+    pendingUpdate = Runnable {
+      updateCustomView()
+      pendingUpdate = null
+    }.also { runnable ->
+      updateHandler.postDelayed(runnable, 16)  // 약 1프레임 딜레이
+    }
+  }
+
   override fun onDropViewInstance() {
+    updateHandler.removeCallbacksAndMessages(null)  // pending 업데이트 제거
+    pendingUpdate = null
+    recycleBitmap()
+    customView = null
     overlay.map = null
     overlay.onClickListener = null
     super.onDropViewInstance()
@@ -62,23 +153,21 @@ class RNCNaverMapMarker(
     super.addView(view, index)
     isImageSetFromSubview = true
     if (view.layoutParams == null) {
-      view.setLayoutParams(
-        LayoutParams(
-          LayoutParams.WRAP_CONTENT,
-          LayoutParams.WRAP_CONTENT,
-        ),
+      view.layoutParams = LayoutParams(
+        LayoutParams.WRAP_CONTENT,
+        LayoutParams.WRAP_CONTENT,
       )
     }
+
     ViewChangesTracker.getInstance().addMarker(this)
     customView = view
-    updateCustomView()
-    overlay.alpha = 1f
+    scheduleUpdate()
   }
 
   fun removeCustomView(index: Int) {
     customView = null
     ViewChangesTracker.getInstance().removeMarker(this)
-    if (customViewBitmap != null && !customViewBitmap!!.isRecycled) customViewBitmap!!.recycle()
+    recycleBitmap()
     isImageSetFromSubview = false
     setImageWithLastImage()
     super.removeView(children.elementAt(index))
@@ -92,46 +181,21 @@ class RNCNaverMapMarker(
     }
   }
 
-  private fun updateCustomView() {
-    if (customViewBitmap == null ||
-      customViewBitmap!!.isRecycled ||
-      customViewBitmap?.getWidth() != overlay.width ||
-      customViewBitmap?.getHeight() != overlay.height
-    ) {
-      customViewBitmap =
-        Bitmap.createBitmap(
-          max(1, overlay.width),
-          max(1, overlay.height),
-          Bitmap.Config.ARGB_4444,
-        )
-    }
-    if (customView != null) {
-      customViewBitmap?.also { bitmap ->
-        bitmap.eraseColor(Color.TRANSPARENT)
-        val canvas = Canvas(bitmap)
-        draw(canvas)
-        setOverlayImage(OverlayImage.fromBitmap(bitmap))
-      }
-    }
+  override fun update(width: Int, height: Int) {
+    scheduleUpdate()
   }
 
   override fun skipTryRender(): Boolean = isImageSetFromSubview
 
   override fun updateCustomForTracking(): Boolean = true
 
-  override fun update(
-    width: Int,
-    height: Int,
-  ) {
-    updateCustomView()
-  }
-
   override fun setOverlayAlpha(alpha: Float) {
     overlay.alpha = alpha
   }
 
   override fun setOverlayImage(image: OverlayImage?) {
-    overlay.icon =
-      image ?: OverlayImage.fromBitmap(Bitmap.createBitmap(0, 0, Bitmap.Config.ARGB_8888))
+    overlay.icon = image ?: OverlayImage.fromBitmap(
+      Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    )
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

- recycleBitmap() 메서드를 추가하여 비트맵 리소스 해제를 체계적으로 관리 하도록 변경했습니다.
- Bitmap 생성 시 ARGB_4444 대신 ARGB_8888 포맷을 사용하여 이미지 품질을 높였습니다.
- isUpdating 플래그를 추가하여 동시에 여러 업데이트가 발생하지 않도록 했습니다.
- updateCustomView() 메서드에 @Synchronized를 추가하고 예외 처리를 추가했습니다.
- 디바운싱 처리를 위한 updateHandler와 scheduleUpdate() 메서드를 추가했습니다.
- 커스텀 뷰 업데이트 로직을 최적화하여 불필요한 비트맵 생성을 감소시켰습니다.
- 초기 마커 아이콘을 투명한 1x1 비트맵으로 설정하여 깜빡임 현상을 방지했습니다.
- pendingMap 변수를 추가하여 커스텀 뷰가 준비된 후에 맵에 마커를 추가하도록 했습니다.
- onDropViewInstance()에서 모든 리소스(핸들러, 비트맵, 리스너 등)를 정리하도록 했습니다.


## TODO
- updateCustomView()에 @Synchronized를 사용했는데, 이미 isUpdating 플래그로 동기화를 처리하고 있어서 중복될 수도 있을 것 같습니다. 둘 중 하나만 사용하는 것을 확인해봐도 좋을 것 같습니다.
- customViewBitmap을 재사용할 때 이전 비트맵을 즉시 재활용하는데, 이때 새 비트맵 생성이 실패할 경우 문제가 될 수도 있을 것 같습니다. 새 비트맵 생성 후 이전 비트맵을 재활용하는 순서가 더 안전할 것 같아 한번 확인이 필요합니다.

