### PR TITLE
fix: iOS  marker 부분 메모리 누수 문제 및 마커 터치 이벤트 수정

### DIFF
--- a/ios/Overlay/Marker/RNCNaverMapMarker.mm
+++ b/ios/Overlay/Marker/RNCNaverMapMarker.mm
@@ -37,26 +37,7 @@ using namespace facebook::react;
   if ((self = [super init])) {
     _inner = [NMFMarker new];
     _isImageSetFromSubview = NO;
-
-    __weak RNCNaverMapMarker *weakSelf = self;
-    _inner.touchHandler = ^BOOL(NMFOverlay* overlay) {
-      RNCNaverMapMarker *strongSelf = weakSelf;
-      if (!strongSelf || !strongSelf->_inner || !strongSelf->_inner.mapView) {
-        return NO;
-      }
-
-      if (strongSelf->_inner.hidden || strongSelf->_inner.alpha <= 0) {
-        return NO;
-      }
-
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (strongSelf && strongSelf.emitter) {
-          strongSelf.emitter->onTapOverlay({});
-        }
-      });
-
-      return YES;
-    };
+    [self setupTouchHandler];
   }
   return self;
 }
@@ -83,7 +64,6 @@ using namespace facebook::react;
   if (_isImageSetFromSubview) {
     return;
   }
-  _inner.alpha = 0;
 
   // Cancel pending request
   if (_imageCanceller) {
@@ -93,11 +73,35 @@ using namespace facebook::react;
 
   _imageCanceller = nmap::getImage([self bridge], image, ^(NMFOverlayImage* _Nullable image) {
     dispatch_async(dispatch_get_main_queue(), [self, image]() {
-      self.inner.alpha = 1;
-      self.inner.iconImage = image;
+      if (self.inner) {
+        self.inner.iconImage = image;
+        [self setupTouchHandler];
+      }
       self->_imageCanceller = nil;
     });
   });
+}
+
+- (void)setupTouchHandler {
+  __weak RNCNaverMapMarker *weakSelf = self;
+  _inner.touchHandler = ^BOOL(NMFOverlay* overlay) {
+    RNCNaverMapMarker *strongSelf = weakSelf;
+    if (!strongSelf || !strongSelf->_inner || !strongSelf->_inner.mapView) {
+      return NO;
+    }
+
+    if (strongSelf->_inner.hidden || strongSelf->_inner.alpha <= 0) {
+      return NO;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (strongSelf && strongSelf.emitter) {
+        strongSelf.emitter->onTapOverlay({});
+      }
+    });
+    
+    return YES;
+  };
 }
 
 #pragma clang diagnostic push
@@ -219,6 +223,8 @@ using namespace facebook::react;
     _inner.subCaptionMinZoom = caption.minZoom;
     _inner.subCaptionMaxZoom = caption.maxZoom;
   }
+
+  [self setupTouchHandler];
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/ios/Overlay/Marker/RNCNaverMapMarker.mm
+++ b/ios/Overlay/Marker/RNCNaverMapMarker.mm
@@ -38,15 +38,26 @@ using namespace facebook::react;
     _inner = [NMFMarker new];
     _isImageSetFromSubview = NO;
 
-    _inner.touchHandler = [self](NMFOverlay* overlay) -> BOOL {
-      if (self.emitter) {
-        self.emitter->onTapOverlay({});
-        return YES;
+    __weak RNCNaverMapMarker *weakSelf = self;
+    _inner.touchHandler = ^BOOL(NMFOverlay* overlay) {
+      RNCNaverMapMarker *strongSelf = weakSelf;
+      if (!strongSelf || !strongSelf->_inner || !strongSelf->_inner.mapView) {
+        return NO;
       }
-      return NO;
+
+      if (strongSelf->_inner.hidden || strongSelf->_inner.alpha <= 0) {
+        return NO;
+      }
+
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (strongSelf && strongSelf.emitter) {
+          strongSelf.emitter->onTapOverlay({});
+        }
+      });
+
+      return YES;
     };
   }
-
   return self;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

- 클로저에서 self를 직접 캡처하면 순환 참조가 발생할 수 있어 weak 참조를 사용하여 마커 객체가 제대로 해재되도록 변경
- 숨겨진 마커나 투명한 마커에서 터치 이벤트가 발생하지 않도록 수정
- 마커가 재생성 된 후 터치 이벤트가 안눌렸던 이슈 수정

