### PR TITLE
fix: iOS에서 줌 컨트롤 활성화 여부가 제대로 작동하지 않는 이슈 수정

### DIFF
--- a/ios/RNCNaverMapViewImpl.mm
+++ b/ios/RNCNaverMapViewImpl.mm
@@ -34,6 +34,7 @@
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
     _reactSubviews = [NSMutableArray new];
+    self.showZoomControls = NO;
 
     [self.mapView addCameraDelegate:self];
     [self.mapView setTouchDelegate:self];


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

줌 컨트롤 활성화 유무 설정시 iOS 에서 제대로 작동하지 않는 이슈를 수정합니다.

네이버맵 sdk에서는 기본값이 Yes로 되어있는데 이 라이브러리에선 기본값을 No라고 생각하고 있었어서 발생한 이슈입니다. 해당 값을 수정해줍니다.

https://navermaps.github.io/ios-map-sdk/reference/Classes/NMFNaverMapView.html#/c:objc(cs)NMFNaverMapView(py)showZoomControls  

![image](https://github.com/user-attachments/assets/0b6845c5-000c-4f8f-a6bc-3f9ba926c99c)


